### PR TITLE
Add additional weight to taur characters

### DIFF
--- a/GainStation13/code/obj/structure/scale.dm
+++ b/GainStation13/code/obj/structure/scale.dm
@@ -50,14 +50,14 @@
 	//The appearance of the numbers changes with the fat level of the character
 	if (HAS_TRAIT(fatty, TRAIT_BLOB))
 		to_chat(fatty, "<span class='userdanger'><span class='big'>[round(src.lastreading/2000, 0.01)]TONS!!!</span></span>")
-	
+
 	else if (HAS_TRAIT(fatty, TRAIT_IMMOBILE))
 		to_chat(fatty, "<span class='boldannounce'>[src.lastreading]Lbs!</span>")
 
 	else if(HAS_TRAIT(fatty, TRAIT_OBESE) || HAS_TRAIT(fatty, TRAIT_MORBIDLYOBESE))
 		to_chat(fatty, "<span class='alert'>[src.lastreading]Lbs!</span>")
 
-	else 
+	else
 		to_chat(fatty, "<span class='notice'>[src.lastreading]Lbs.</span>")
 
 
@@ -70,7 +70,7 @@
 				weighperson(HM)
 
 /obj/structure/scale/proc/weighperson(mob/living/carbon/human/fatty)
-	src.lastreading = round((140 + (fatty.fatness*src.fatnessToWeight))*(fatty.size_multiplier**2))
+	src.lastreading = round((140 + (fatty.fatness*src.fatnessToWeight))*(fatty.size_multiplier**2)*((fatty.dna.features["taur"] != "None") ? 2.5: 1))
 	weighEffect(fatty)
 	visible_message("<span class='notice'>[fatty] weighs themselves.</span>")
 	visible_message("<span class='notice'>The numbers on the screen settle on: [src.lastreading]Lbs.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds additional weight to taur characters when they go on scales. It's 2.5x for taur characters, meaning at 0 fatness a taur character will report a weight of 350 pounds while a non-taur character will report a weight of 140 pounds. Math was based on the assumption of a taur body adding at least 200 or so pounds (by default!), then making it multiplicative to imply the tauric half was also gaining weight.
![example](https://github.com/SeepingVisage/GS13/assets/160535199/ef009d89-ac69-460a-a558-f0a63bd71560)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think it's strange that a taur who, at the same "fatness" as a non-taur character, will have the same weight, despite having an additional torso and even extra limbs. We already have a weight multiplier for people who scale their sprites, so I thought it would make sense to also have a multiplier for taurs. It might be useful to make it so that it differentiates between taur types (fat naga would weigh more than a deer, probably) but at the moment it just checks if the character isn't not a taur and applies the 2.5x.
I can foresee this making it so that people going for a massive gain record might pick taur, but the scale factor alone can multiply the character's weight by 4x.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: harlieharhar
tweak: taurs now weigh 2.5x as much on a scale
balance: taurs now weigh 2.5x as much on a scale. this could create a new meta for "getting huge numbers of fat"
code: added a check for if a character is a taur when they step on the scale
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
